### PR TITLE
Add support for raw ecdsa without hashing

### DIFF
--- a/src/main/java/com/licel/jcardsim/crypto/SignatureProxy.java
+++ b/src/main/java/com/licel/jcardsim/crypto/SignatureProxy.java
@@ -102,5 +102,10 @@ public class SignatureProxy {
         }
         return instance;
     }
-    
+
+    public static final Signature getInstance(byte messageDigestAlgorithm, byte cipherAlgorithm,
+            byte paddingAlgorithm, boolean externalAccess) throws CryptoException {
+        return new AsymmetricSignatureImpl(messageDigestAlgorithm, cipherAlgorithm, paddingAlgorithm);
+    }
+
 }


### PR DESCRIPTION
Allows
```
Signature.getInstance(MessageDigest.ALG_NULL, Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
```
Related to https://github.com/OpenSC/OpenSC/pull/2642 and https://github.com/philipWendland/IsoApplet/pull/28